### PR TITLE
lavu: add NV20 bitstream format support

### DIFF
--- a/libavutil/imgutils.c
+++ b/libavutil/imgutils.c
@@ -341,19 +341,6 @@ int av_image_check_sar(unsigned int w, unsigned int h, AVRational sar)
     return AVERROR(EINVAL);
 }
 
-static void image_copy_plane2(uint8_t       *dst, ptrdiff_t dst_linesize,
-                              const uint8_t *src, ptrdiff_t src_linesize,
-                              ptrdiff_t bytewidth, int height)
-{
-    if (!dst || !src)
-        return;
-    for (;height > 0; height--) {
-        memcpy(dst, src, bytewidth);
-        dst += dst_linesize;
-        src += src_linesize;
-    }
-}
-
 static void image_copy_plane(uint8_t       *dst, ptrdiff_t dst_linesize,
                              const uint8_t *src, ptrdiff_t src_linesize,
                              ptrdiff_t bytewidth, int height)
@@ -362,9 +349,11 @@ static void image_copy_plane(uint8_t       *dst, ptrdiff_t dst_linesize,
         return;
     av_assert0(FFABS(src_linesize) >= bytewidth);
     av_assert0(FFABS(dst_linesize) >= bytewidth);
-    image_copy_plane2(dst, dst_linesize,
-                      src, src_linesize,
-                      bytewidth, height);
+    for (;height > 0; height--) {
+        memcpy(dst, src, bytewidth);
+        dst += dst_linesize;
+        src += src_linesize;
+    }
 }
 
 void av_image_copy_plane_uc_from(uint8_t *dst, ptrdiff_t dst_linesize,
@@ -435,8 +424,7 @@ void av_image_copy(uint8_t *const dst_data[4], const int dst_linesizes[4],
                    enum AVPixelFormat pix_fmt, int width, int height)
 {
     ptrdiff_t dst_linesizes1[4], src_linesizes1[4];
-    int i, is_nv15_20 = pix_fmt == AV_PIX_FMT_NV15 ||
-                        pix_fmt == AV_PIX_FMT_NV20;
+    int i;
 
     for (i = 0; i < 4; i++) {
         dst_linesizes1[i] = dst_linesizes[i];
@@ -444,7 +432,7 @@ void av_image_copy(uint8_t *const dst_data[4], const int dst_linesizes[4],
     }
 
     image_copy(dst_data, dst_linesizes1, src_data, src_linesizes1, pix_fmt,
-               width, height, is_nv15_20 ? image_copy_plane2 : image_copy_plane);
+               width, height, image_copy_plane);
 }
 
 void av_image_copy_uc_from(uint8_t * const dst_data[4], const ptrdiff_t dst_linesizes[4],

--- a/libavutil/pixdesc.c
+++ b/libavutil/pixdesc.c
@@ -2805,6 +2805,18 @@ static const AVPixFmtDescriptor av_pix_fmt_descriptors[AV_PIX_FMT_NB] = {
         },
         .flags = AV_PIX_FMT_FLAG_PLANAR | AV_PIX_FMT_FLAG_BITSTREAM,
     },
+    [AV_PIX_FMT_NV20] = {
+        .name = "nv20",
+        .nb_components = 3,
+        .log2_chroma_w = 1,
+        .log2_chroma_h = 0,
+        .comp = {
+            { 0, 10,  0, 0, 10 },      /* Y */
+            { 1, 20,  0, 0, 10 },      /* U */
+            { 1, 20, 10, 0, 10 },      /* V */
+        },
+        .flags = AV_PIX_FMT_FLAG_PLANAR | AV_PIX_FMT_FLAG_BITSTREAM,
+    },
 };
 
 static const char * const color_range_names[] = {

--- a/libavutil/pixfmt.h
+++ b/libavutil/pixfmt.h
@@ -189,8 +189,8 @@ enum AVPixelFormat {
     AV_PIX_FMT_XYZ12LE,      ///< packed XYZ 4:4:4, 36 bpp, (msb) 12X, 12Y, 12Z (lsb), the 2-byte value for each X/Y/Z is stored as little-endian, the 4 lower bits are set to 0
     AV_PIX_FMT_XYZ12BE,      ///< packed XYZ 4:4:4, 36 bpp, (msb) 12X, 12Y, 12Z (lsb), the 2-byte value for each X/Y/Z is stored as big-endian, the 4 lower bits are set to 0
     AV_PIX_FMT_NV16,         ///< interleaved chroma YUV 4:2:2, 16bpp, (1 Cr & Cb sample per 2x1 Y samples)
-    AV_PIX_FMT_NV20LE,       ///< interleaved chroma YUV 4:2:2, 20bpp, (1 Cr & Cb sample per 2x1 Y samples), little-endian
-    AV_PIX_FMT_NV20BE,       ///< interleaved chroma YUV 4:2:2, 20bpp, (1 Cr & Cb sample per 2x1 Y samples), big-endian
+    AV_PIX_FMT_NV20LE,       ///< interleaved chroma YUV 4:2:2, 20bpp, (1 Cr & Cb sample per 2x1 Y samples), little-endian, deprecated in favor of AV_PIX_FMT_NV20
+    AV_PIX_FMT_NV20BE,       ///< interleaved chroma YUV 4:2:2, 20bpp, (1 Cr & Cb sample per 2x1 Y samples), big-endian, deprecated in favor of AV_PIX_FMT_NV20
 
     AV_PIX_FMT_RGBA64BE,     ///< packed RGBA 16:16:16:16, 64bpp, 16R, 16G, 16B, 16A, the 2-byte value for each R/G/B/A component is stored as big-endian
     AV_PIX_FMT_RGBA64LE,     ///< packed RGBA 16:16:16:16, 64bpp, 16R, 16G, 16B, 16A, the 2-byte value for each R/G/B/A component is stored as little-endian
@@ -429,7 +429,8 @@ enum AVPixelFormat {
     AV_PIX_FMT_GBRAP14BE,  ///< planar GBR 4:4:4:4 56bpp, big-endian
     AV_PIX_FMT_GBRAP14LE,  ///< planar GBR 4:4:4:4 56bpp, little-endian
 
-    AV_PIX_FMT_NV15,        ///< like P010, but has no zero padding bits, 15bpp, little-endian
+    AV_PIX_FMT_NV15,        ///< like P010, but has no zero padding bits, 15bpp, bitstream
+    AV_PIX_FMT_NV20,        ///< like P210, but has no zero padding bits, 20bpp, bitstream
 
     AV_PIX_FMT_NB         ///< number of pixel formats, DO NOT USE THIS if you want to link with shared libav* because the number of formats might differ between versions
 };
@@ -515,7 +516,6 @@ enum AVPixelFormat {
 #define AV_PIX_FMT_YUVA444P16 AV_PIX_FMT_NE(YUVA444P16BE, YUVA444P16LE)
 
 #define AV_PIX_FMT_XYZ12      AV_PIX_FMT_NE(XYZ12BE, XYZ12LE)
-#define AV_PIX_FMT_NV20       AV_PIX_FMT_NE(NV20BE,  NV20LE)
 #define AV_PIX_FMT_AYUV64     AV_PIX_FMT_NE(AYUV64BE, AYUV64LE)
 #define AV_PIX_FMT_P010       AV_PIX_FMT_NE(P010BE,  P010LE)
 #define AV_PIX_FMT_P012       AV_PIX_FMT_NE(P012BE,  P012LE)

--- a/tests/ref/fate/imgutils
+++ b/tests/ref/fate/imgutils
@@ -269,3 +269,4 @@ p412le          planes: 2, linesizes: 128 256   0   0, plane_sizes:  6144 12288 
 gbrap14be       planes: 4, linesizes: 128 128 128 128, plane_sizes:  6144  6144  6144  6144, plane_offsets:  6144  6144  6144, total_size: 24576
 gbrap14le       planes: 4, linesizes: 128 128 128 128, plane_sizes:  6144  6144  6144  6144, plane_offsets:  6144  6144  6144, total_size: 24576
 nv15            planes: 2, linesizes:  80  80   0   0, plane_sizes:  3840  1920     0     0, plane_offsets:  3840     0     0, total_size: 5760
+nv20            planes: 2, linesizes:  80  80   0   0, plane_sizes:  3840  3840     0     0, plane_offsets:  3840     0     0, total_size: 7680

--- a/tests/ref/fate/sws-pixdesc-query
+++ b/tests/ref/fate/sws-pixdesc-query
@@ -62,6 +62,7 @@ isNBPS:
   gray9be
   gray9le
   nv15
+  nv20
   nv20be
   nv20le
   p010be
@@ -224,6 +225,7 @@ isYUV:
   nv12
   nv15
   nv16
+  nv20
   nv20be
   nv20le
   nv21
@@ -341,6 +343,7 @@ isPlanarYUV:
   nv12
   nv15
   nv16
+  nv20
   nv20be
   nv20le
   nv21
@@ -439,6 +442,7 @@ isSemiPlanarYUV:
   nv12
   nv15
   nv16
+  nv20
   nv20be
   nv20le
   nv21
@@ -874,6 +878,7 @@ Planar:
   nv12
   nv15
   nv16
+  nv20
   nv20be
   nv20le
   nv21


### PR DESCRIPTION
- lavu: add NV20 bitstream format support
- Revert "HACK: lavu: allow image copy for NV15 and NV20"