### PR TITLE
rkmppdec: allow user to force drm:prime format when decoding to prevent

### DIFF
--- a/libavcodec/rkmppdec.c
+++ b/libavcodec/rkmppdec.c
@@ -176,6 +176,11 @@ static av_cold int rkmpp_decode_init(AVCodecContext *avctx)
         break;
     }
 
+    if (r->forcedrm){
+        is_fmt_supported = 1;
+        avctx->pix_fmt = AV_PIX_FMT_DRM_PRIME;
+    }
+
     if (avctx->pix_fmt != AV_PIX_FMT_DRM_PRIME) {
         if (!is_fmt_supported) {
             av_log(avctx, AV_LOG_ERROR, "MPP doesn't support codec '%s' with pix_fmt '%s'\n",

--- a/libavcodec/rkmppdec.h
+++ b/libavcodec/rkmppdec.h
@@ -64,6 +64,7 @@ typedef struct RKMPPDecContext {
     int            afbc;
     int            fast_parse;
     int            buf_mode;
+    int            forcedrm;
 } RKMPPDecContext;
 
 enum {
@@ -98,6 +99,7 @@ static const AVOption options[] = {
     { "buf_mode",   "Set the buffer mode for MPP decoder", OFFSET(buf_mode), AV_OPT_TYPE_INT, { .i64 = RKMPP_DEC_HALF_INTERNAL }, 0, 1, VD, "buf_mode" },
         { "half",   "Half internal mode",                      0, AV_OPT_TYPE_CONST, { .i64 = RKMPP_DEC_HALF_INTERNAL }, 0, 0, VD, "buf_mode" },
         { "ext",    "Pure external mode",                      0, AV_OPT_TYPE_CONST, { .i64 = RKMPP_DEC_PURE_EXTERNAL }, 0, 0, VD, "buf_mode" },
+    { "forcedrm",   "Force drm_prime output", OFFSET(forcedrm), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VD },
     { NULL }
 };
 


### PR DESCRIPTION
as in [case](https://forum.radxa.com/t/archlinux-on-rock5b/13851/411?u=boogiepop) some players can not pickup the right format.

in the cases where it is obvious like [moonlight](https://github.com/moonlight-stream/moonlight-qt/pull/1167) i create mainline PRs to players but there are such corner cases as mpv's i really dont know where the exact issue is.

ie: mpv picks up
correct drm_prime format for https://www.youtube.com/watch?v=aqz-KE-bpKQ, vp9 with mp4
but not for https://youtu.be/BJ3Yv572V1A, h264 with hls. choses nv12.
could be even a demuxer/container issue, who knows.

can we provide such a workaround for those cases?

as a side note, i would just suggest completely removing any form of format which is not drm_prime. It saves from future pain.