### PR TITLE
lavc/rkmppdec: export HDR10+ and HDR Vivid dynamic metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project aims to provide full hardware transcoding pipeline in FFmpeg CLI fo
 * MPP decoders support producing AFBC (ARM Frame Buffer Compression) image
 * MPP decoders support de-interlace using IEP (Image Enhancement Processor)
 * MPP decoders support allocator half-internal and pure-external modes
+* MPP decoders export static and dynamic (HDR10+, HDR Vivid) HDR metadata
 * MPP encoders support up to 8K H.264 and HEVC encoding
 * MPP encoders support async encoding, AKA frame-parallel
 * MPP encoders support consuming AFBC image

--- a/configure
+++ b/configure
@@ -7511,7 +7511,7 @@ enabled openssl           && { { check_pkg_config openssl "openssl >= 3.0.0" ope
                                check_lib openssl openssl/ssl.h DTLS_get_data_mtu -lssl -lcrypto -lws2_32 -lgdi32 ||
                                die "ERROR: openssl (>= 1.1.1) not found"; }
 enabled pocketsphinx      && require_pkg_config pocketsphinx pocketsphinx pocketsphinx/pocketsphinx.h ps_init
-enabled rkmpp             && { require_pkg_config rkmpp "rockchip_mpp >= 1.3.9" "rockchip/rk_mpi.h rockchip/mpp_buffer.h" "mpp_create mpp_buffer_sync_begin_f" &&
+enabled rkmpp             && { require_pkg_config rkmpp "rockchip_mpp >= 1.3.9" "rockchip/rk_mpi.h rockchip/mpp_buffer.h rockchip/mpp_frame.h" "mpp_create mpp_buffer_sync_begin_f mpp_frame_get_hdr_dynamic_meta" &&
                                { enabled libdrm ||
                                  die "ERROR: rkmpp requires --enable-libdrm"; }
                              }

--- a/libavcodec/rkmppdec.c
+++ b/libavcodec/rkmppdec.c
@@ -30,6 +30,11 @@
 
 #include "rkmppdec.h"
 
+#include "libavutil/hdr_dynamic_metadata.h"
+#if CONFIG_HEVC_SEI
+#include "dynamic_hdr_vivid.h"
+#endif
+
 #include <fcntl.h>
 #include <unistd.h>
 #if CONFIG_RKRGA
@@ -559,6 +564,59 @@ static int rkmpp_export_content_light(AVFrame *frame,
     return 0;
 }
 
+static int rkmpp_export_dynamic_hdr(AVCodecContext *avctx, AVFrame *frame,
+                                    MppFrame mpp_frame)
+{
+    MppFrameHdrDynamicMeta *meta = mpp_frame_get_hdr_dynamic_meta(mpp_frame);
+    int ret;
+
+    if (!meta || !meta->size)
+        return 0;
+
+    switch (meta->hdr_fmt) {
+    case HDR10PLUS: {
+        AVDynamicHDRPlus *hdrplus = av_dynamic_hdr_plus_create_side_data(frame);
+        if (!hdrplus)
+            return AVERROR(ENOMEM);
+
+        /* The MPP payload starts from the application mode byte, which is
+         * exactly what the T.35 parser expects */
+        ret = av_dynamic_hdr_plus_from_t35(hdrplus, meta->data, meta->size);
+        if (ret < 0) {
+            av_log(avctx, AV_LOG_DEBUG, "Failed to parse HDR10+ metadata: %d\n", ret);
+            av_frame_remove_side_data(frame, AV_FRAME_DATA_DYNAMIC_HDR_PLUS);
+        }
+        break;
+    }
+#if CONFIG_HEVC_SEI
+    case HDRVIVID: {
+        AVDynamicHDRVivid *vivid = av_dynamic_hdr_vivid_create_side_data(frame);
+        if (!vivid)
+            return AVERROR(ENOMEM);
+
+        /* The MPP payload starts from the CUVA system start code */
+        ret = ff_parse_itu_t_t35_to_dynamic_hdr_vivid(vivid, meta->data, meta->size);
+        if (ret < 0) {
+            av_log(avctx, AV_LOG_DEBUG, "Failed to parse HDR Vivid metadata: %d\n", ret);
+            av_frame_remove_side_data(frame, AV_FRAME_DATA_DYNAMIC_HDR_VIVID);
+        }
+        break;
+    }
+#endif
+    case HDR10:
+    case HLG:
+        /* static only, nothing to export here */
+        break;
+    case DLBY:
+    default:
+        av_log(avctx, AV_LOG_VERBOSE, "Unsupported dynamic HDR format: %u\n",
+               (unsigned)meta->hdr_fmt);
+        break;
+    }
+
+    return 0;
+}
+
 static void rkmpp_free_mpp_frame(void *opaque, uint8_t *data)
 {
     MppFrame mpp_frame = (MppFrame)opaque;
@@ -686,13 +744,21 @@ static int rkmpp_export_frame(AVCodecContext *avctx, AVFrame *frame, MppFrame mp
                                               (AVRational) { frame->width, frame->height });
     }
 
-    if (avctx->codec_id == AV_CODEC_ID_HEVC &&
+    if ((avctx->codec_id == AV_CODEC_ID_HEVC ||
+         avctx->codec_id == AV_CODEC_ID_AV1) &&
         (frame->color_trc == AVCOL_TRC_SMPTE2084 ||
          frame->color_trc == AVCOL_TRC_ARIB_STD_B67)) {
         ret = rkmpp_export_mastering_display(avctx, frame, mpp_frame_get_mastering_display(mpp_frame));
         if (ret < 0)
             return ret;
         ret = rkmpp_export_content_light(frame, mpp_frame_get_content_light(mpp_frame));
+        if (ret < 0)
+            return ret;
+    }
+
+    if (avctx->codec_id == AV_CODEC_ID_HEVC ||
+        avctx->codec_id == AV_CODEC_ID_AV1) {
+        ret = rkmpp_export_dynamic_hdr(avctx, frame, mpp_frame);
         if (ret < 0)
             return ret;
     }

--- a/libavcodec/rkmppdec.h
+++ b/libavcodec/rkmppdec.h
@@ -28,6 +28,7 @@
 #ifndef AVCODEC_RKMPPDEC_H
 #define AVCODEC_RKMPPDEC_H
 
+#include <rockchip/rk_hdr_meta_com.h>
 #include <rockchip/rk_mpi.h>
 
 #include "codec_internal.h"


### PR DESCRIPTION
Export per-frame HDR dynamic metadata that the MPP decoder already parses
from HEVC and AV1 streams to the corresponding AVFrame side data:

- SMPTE ST 2094-40 (HDR10+) -> AV_FRAME_DATA_DYNAMIC_HDR_PLUS
- CUVA HDR Vivid             -> AV_FRAME_DATA_DYNAMIC_HDR_VIVID

Static HDR export (mastering display / content light level) is also extended
from HEVC-only to AV1.

## Implementation
- `mpp_frame_get_hdr_dynamic_meta()` returns the SEI payload per frame;
  for HDR10+ the payload starts at the application mode byte, which is
  exactly what `av_dynamic_hdr_plus_from_t35()` expects (verified
  byte-for-byte against the soft decoder); for HDR Vivid the payload is the
  CUVA T.35 register segment parsed by
  `ff_parse_itu_t_t35_to_dynamic_hdr_vivid()` (guarded by CONFIG_HEVC_SEI).
- Parse failures only log and drop the side data; decoding continues.
- Dolby Vision payloads are skipped (no matching FFmpeg side data type for
  the RPU-only variant MPP exposes).
- configure gains a hard symbol gate on `mpp_frame_get_hdr_dynamic_meta`
  (present in current MPP develop).

## Verification (on-device)
- HDR10+ HEVC: hw and soft decoder agree on 300/300 frames with side data;
  frame-0 metadata fields identical.
- HDR10+ AV1 (mkv block-additions carrier): hw exports 300/300; native av1
  soft decoder cannot parse the carrier, so ground truth verified via OBU
  scan of the raw bitstream.
- HDR Vivid HEVC: hw=sw=1 frame, fields match.
- Plain HDR10 content: only static metadata, as expected.

## Known upstream limitation (filed against MPP separately)
For streams where the dynamic SEI appears in multiple AUs, MPP only attaches
it to the first frame (h265 parser latches the SEI). Streams repeating the
SEI in every AU are unaffected.
