### PR TITLE
lavc/rkmppdec: add hardware thumbnail (half-resolution) decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project aims to provide full hardware transcoding pipeline in FFmpeg CLI fo
 * MPP decoders support producing AFBC (ARM Frame Buffer Compression) image
 * MPP decoders support de-interlace using IEP (Image Enhancement Processor)
 * MPP decoders support allocator half-internal and pure-external modes
+* MPP decoders support hardware thumbnail (half-resolution) decoding on capable SoCs
 * MPP encoders support up to 8K H.264 and HEVC encoding
 * MPP encoders support async encoding, AKA frame-parallel
 * MPP encoders support consuming AFBC image

--- a/configure
+++ b/configure
@@ -7511,7 +7511,7 @@ enabled openssl           && { { check_pkg_config openssl "openssl >= 3.0.0" ope
                                check_lib openssl openssl/ssl.h DTLS_get_data_mtu -lssl -lcrypto -lws2_32 -lgdi32 ||
                                die "ERROR: openssl (>= 1.1.1) not found"; }
 enabled pocketsphinx      && require_pkg_config pocketsphinx pocketsphinx pocketsphinx/pocketsphinx.h ps_init
-enabled rkmpp             && { require_pkg_config rkmpp "rockchip_mpp >= 1.3.9" "rockchip/rk_mpi.h rockchip/mpp_buffer.h" "mpp_create mpp_buffer_sync_begin_f" &&
+enabled rkmpp             && { require_pkg_config rkmpp "rockchip_mpp >= 1.3.9" "rockchip/rk_mpi.h rockchip/mpp_buffer.h rockchip/mpp_frame.h" "mpp_create mpp_buffer_sync_begin_f mpp_frame_get_thumbnail_en" &&
                                { enabled libdrm ||
                                  die "ERROR: rkmpp requires --enable-libdrm"; }
                              }

--- a/libavcodec/rkmppdec.c
+++ b/libavcodec/rkmppdec.c
@@ -30,6 +30,8 @@
 
 #include "rkmppdec.h"
 
+#include <rockchip/rk_vdec_cfg.h>
+
 #include <fcntl.h>
 #include <unistd.h>
 #if CONFIG_RKRGA
@@ -191,6 +193,38 @@ static av_cold int rkmpp_decode_init(AVCodecContext *avctx)
     if (opts_env && av_set_options_string(r, opts_env, "=", " ") <= 0)
         av_log(avctx, AV_LOG_WARNING, "Unable to set decoder options from env\n");
 
+    if (r->thumbnail) {
+        if (avctx->codec_id != AV_CODEC_ID_H264 &&
+            avctx->codec_id != AV_CODEC_ID_HEVC &&
+            avctx->codec_id != AV_CODEC_ID_VP9  &&
+            avctx->codec_id != AV_CODEC_ID_AV1) {
+            av_log(avctx, AV_LOG_WARNING,
+                   "Thumbnail mode is not supported in codec '%s', ignoring\n",
+                   avcodec_get_name(avctx->codec_id));
+            r->thumbnail = 0;
+        } else {
+            /*
+             * Hardware downscale output only exists in the vdpu383/vdpu384
+             * decoder cores (rk3562/rk3576/rk3572). On other SoCs MPP accepts
+             * enable_thumbnail but never outputs any frame, so gate it here.
+             */
+            char tbn_soc[128] = { 0 };
+            read_soc_name(avctx, tbn_soc, sizeof(tbn_soc));
+            if (!strstr(tbn_soc, "rk3576") &&
+                !strstr(tbn_soc, "rk3572") &&
+                !strstr(tbn_soc, "rk3562")) {
+                av_log(avctx, AV_LOG_WARNING,
+                       "Thumbnail mode is not supported on this SoC (%s), ignoring\n",
+                       tbn_soc);
+                r->thumbnail = 0;
+            } else {
+                /* The downscaled output is raster-only 8-bit 4:2:0 */
+                r->deint = 0;
+                r->afbc  = RKMPP_DEC_AFBC_OFF;
+            }
+        }
+    }
+
     switch (avctx->pix_fmt) {
     case AV_PIX_FMT_YUV420P:
     case AV_PIX_FMT_YUVJ420P:
@@ -233,6 +267,12 @@ static av_cold int rkmpp_decode_init(AVCodecContext *avctx)
         break;
     }
 
+    if (r->thumbnail) {
+        /* The downscaled output is always 8-bit 4:2:0 */
+        pix_fmts[1]      = AV_PIX_FMT_NV12;
+        is_fmt_supported = 1;
+    }
+
     if (avctx->pix_fmt != AV_PIX_FMT_DRM_PRIME) {
         if (!is_fmt_supported) {
             av_log(avctx, AV_LOG_ERROR, "MPP doesn't support codec '%s' with pix_fmt '%s'\n",
@@ -268,6 +308,26 @@ static av_cold int rkmpp_decode_init(AVCodecContext *avctx)
         av_log(avctx, AV_LOG_ERROR, "Failed to init MPP context: %d\n", ret);
         ret = AVERROR_EXTERNAL;
         goto fail;
+    }
+
+    if (r->thumbnail) {
+        MppDecCfg dec_cfg = NULL;
+
+        ret = mpp_dec_cfg_init(&dec_cfg);
+        if (ret == MPP_OK) {
+            ret = r->mapi->control(r->mctx, MPP_DEC_GET_CFG, dec_cfg);
+            if (ret == MPP_OK)
+                ret = mpp_dec_cfg_set_u32(dec_cfg, "base:enable_thumbnail",
+                                          MPP_FRAME_THUMBNAIL_ONLY);
+            if (ret == MPP_OK)
+                ret = r->mapi->control(r->mctx, MPP_DEC_SET_CFG, dec_cfg);
+            mpp_dec_cfg_deinit(dec_cfg);
+        }
+        if (ret != MPP_OK) {
+            av_log(avctx, AV_LOG_WARNING,
+                   "Failed to enable thumbnail mode in MPP: %d\n", ret);
+            r->thumbnail = 0;
+        }
     }
 
     if (avctx->codec_id == AV_CODEC_ID_MJPEG) {
@@ -601,6 +661,45 @@ static int rkmpp_export_frame(AVCodecContext *avctx, AVFrame *frame, MppFrame mp
     if (!frame || !mpp_frame)
         return AVERROR(ENOMEM);
 
+    if (r->thumbnail) {
+        if (!r->thumbnail_resolved) {
+            r->thumbnail_resolved = 1;
+
+            if (mpp_frame_get_thumbnail_en(mpp_frame) == MPP_FRAME_THUMBNAIL_ONLY &&
+                r->mapi->control(r->mctx, MPP_DEC_GET_THUMBNAIL_FRAME_INFO, mpp_frame) == MPP_OK) {
+                r->tbn_width      = mpp_frame_get_width(mpp_frame);
+                r->tbn_height     = mpp_frame_get_height(mpp_frame);
+                r->tbn_hor_stride = mpp_frame_get_hor_stride(mpp_frame);
+                r->tbn_ver_stride = mpp_frame_get_ver_stride(mpp_frame);
+                avctx->width      = r->tbn_width;
+                avctx->height     = r->tbn_height;
+                avctx->sw_pix_fmt = AV_PIX_FMT_NV12;
+                r->thumbnail_active = 1;
+                /* Filters (e.g. hwdownload) size their output from the hw
+                 * frames context, sync it with the thumbnail geometry */
+                if (r->hwframe) {
+                    AVHWFramesContext *hwfc = (AVHWFramesContext *)r->hwframe->data;
+                    hwfc->width  = FFALIGN(r->tbn_width,  16);
+                    hwfc->height = FFALIGN(r->tbn_height, 16);
+                }
+                av_log(avctx, AV_LOG_VERBOSE, "Thumbnail mode is active, output size: %dx%d\n",
+                       avctx->width, avctx->height);
+            } else {
+                av_log(avctx, AV_LOG_WARNING,
+                       "Thumbnail mode is not supported on this SoC, "
+                       "falling back to full-resolution output\n");
+            }
+        } else if (r->thumbnail_active) {
+            /* MPP keeps reporting the full-resolution geometry while the
+             * buffer holds the downscaled image, re-apply the cached one */
+            mpp_frame_set_fmt(mpp_frame, MPP_FMT_YUV420SP);
+            mpp_frame_set_width(mpp_frame, r->tbn_width);
+            mpp_frame_set_height(mpp_frame, r->tbn_height);
+            mpp_frame_set_hor_stride(mpp_frame, r->tbn_hor_stride);
+            mpp_frame_set_ver_stride(mpp_frame, r->tbn_ver_stride);
+        }
+    }
+
     mpp_buf = mpp_frame_get_buffer(mpp_frame);
     if (!mpp_buf)
         return AVERROR(EAGAIN);
@@ -845,6 +944,15 @@ static int rkmpp_get_frame(AVCodecContext *avctx, AVFrame *frame, int timeout)
         }
 
         pix_fmts[1] = rkmpp_get_av_format(mpp_fmt & MPP_FRAME_FMT_MASK);
+
+        if (r->thumbnail) {
+            /* The downscaled output is always 8-bit 4:2:0. If the SoC turns
+             * out to lack downscale support the frames stay full-resolution
+             * but are still exported as NV12-compatible raster. */
+            pix_fmts[1] = AV_PIX_FMT_NV12;
+            r->thumbnail_resolved = 0;
+            r->thumbnail_active   = 0;
+        }
 
         if (avctx->pix_fmt == AV_PIX_FMT_DRM_PRIME)
             avctx->sw_pix_fmt = pix_fmts[1];
@@ -1221,6 +1329,8 @@ static av_cold void rkmpp_decode_flush(AVCodecContext *avctx)
         r->draining = 0;
         r->info_change = 0;
         r->got_frame = 0;
+        r->thumbnail_resolved = 0;
+        r->thumbnail_active   = 0;
 
         av_packet_unref(&r->last_pkt);
     } else

--- a/libavcodec/rkmppdec.h
+++ b/libavcodec/rkmppdec.h
@@ -68,6 +68,14 @@ typedef struct RKMPPDecContext {
     int            afbc;
     int            fast_parse;
     int            buf_mode;
+    int            thumbnail;
+
+    int            thumbnail_resolved;
+    int            thumbnail_active;
+    RK_U32         tbn_width;
+    RK_U32         tbn_height;
+    RK_U32         tbn_hor_stride;
+    RK_U32         tbn_ver_stride;
 } RKMPPDecContext;
 
 enum {
@@ -99,6 +107,7 @@ static const AVOption options[] = {
         { "on",     "Enable AFBC support",                     0, AV_OPT_TYPE_CONST, { .i64 = RKMPP_DEC_AFBC_ON     }, 0, 0, VD, .unit = "afbc" },
         { "rga",    "Enable AFBC if capable RGA is available", 0, AV_OPT_TYPE_CONST, { .i64 = RKMPP_DEC_AFBC_ON_RGA }, 0, 0, VD, .unit = "afbc" },
     { "fast_parse", "Enable fast parsing to improve decoding parallelism", OFFSET(fast_parse), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, VD },
+    { "thumbnail",  "Enable hardware thumbnail (half-resolution) output for supported SoCs", OFFSET(thumbnail), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VD },
     { "buf_mode",   "Set the buffer mode for MPP decoder", OFFSET(buf_mode), AV_OPT_TYPE_INT, { .i64 = RKMPP_DEC_HALF_INTERNAL }, 0, 1, VD, .unit = "buf_mode" },
         { "half",   "Half internal mode",                      0, AV_OPT_TYPE_CONST, { .i64 = RKMPP_DEC_HALF_INTERNAL }, 0, 0, VD, .unit = "buf_mode" },
         { "ext",    "Pure external mode",                      0, AV_OPT_TYPE_CONST, { .i64 = RKMPP_DEC_PURE_EXTERNAL }, 0, 0, VD, .unit = "buf_mode" },


### PR DESCRIPTION
Add a `thumbnail` option (default off) to all rkmpp decoders. On SoCs whose
decoder cores include the hardware downscaler (vdpu383/vdpu384: rk3562,
rk3572, rk3576), enabling it makes the decoder output the half-resolution
thumbnail image that MPP produces alongside the full-resolution picture,
as ordinary 8-bit NV12 frames.

## Design notes
- Configured via `mpp_dec_cfg` `"base:enable_thumbnail" = MPP_FRAME_THUMBNAIL_ONLY`,
  so the output stream is plain half-resolution frames and fits the standard
  FFmpeg decoder model (no extra side-data types, no dual output).
- SoC gate at init: on SoCs without the downscaler MPP accepts the config but
  never outputs frames (observed on rk3588/vdpu580), so the option is disabled
  with a warning there based on `/proc/device-tree/compatible` (same mechanism
  already used elsewhere in rkmppdec.c).
- The thumbnail geometry (w/2, h/2, 16-aligned strides, forced 8-bit) is only
  known after the first frame: resolved lazily via
  `control(MPP_DEC_GET_THUMBNAIL_FRAME_INFO)` on the first frame, then cached
  and re-applied to subsequent frames (MPP keeps reporting the full-resolution
  geometry while the buffer holds the downscaled image). hw_frames_ctx
  dimensions are synced so hwdownload-based filters size their output
  correctly. Resolution changes reset the resolution state.
- Thumbnail output is raster-only 8-bit 4:2:0 (MPP design; 10-bit sources are
  downscaled to 8-bit), so AFBC and deinterlace are force-disabled when the
  option is active.

## Verification (on-device)
- rk3576 (vdpu383): H.264/HEVC/VP9/AV1 samples >= 1080p -> output size =
  source/2 (+-1 for odd dimensions), "Thumbnail mode is active" logged,
  control runs without the option stay full-resolution; 07/08 deep suites
  pass.
- rk3588: option correctly ignored with "not supported on this SoC" warning,
  full-resolution output preserved.
